### PR TITLE
Socks5 support in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Alexander Puzynia <werwolf.by@gmail.com>
 
 COPY monitorrent/requirements.txt /var/www/monitorrent/requirements.txt
 RUN pip install -r /var/www/monitorrent/requirements.txt
+RUN pip install PySocks
 COPY monitorrent /var/www/monitorrent
 
 WORKDIR /var/www/monitorrent

--- a/Dockerfile.x86
+++ b/Dockerfile.x86
@@ -3,6 +3,7 @@ MAINTAINER Alexander Puzynia <werwolf.by@gmail.com>
 
 COPY monitorrent/requirements.txt /var/www/monitorrent/requirements.txt
 RUN pip install --no-cache-dir -r /var/www/monitorrent/requirements.txt
+RUN pip install PySocks
 COPY monitorrent /var/www/monitorrent
 
 WORKDIR /var/www/monitorrent

--- a/env.template
+++ b/env.template
@@ -8,7 +8,7 @@ NETWORKING=bridge
 RESTART_POLICY=always
 
 # build variables default
-MONITORRENT_VERSION=1.1.3
+MONITORRENT_VERSION=1.1.5
 
 # Makefile required
 PORTS=\


### PR DESCRIPTION
Added pysocks dependency to support connections using SOCKS5 proxy.
Bumped monitorrent to latest version

Tested in X86 machine with rutracker.org tracker